### PR TITLE
docs: add branching strategy (Dev → Main workflow) in .github/BRANCHING.md: add branching strategy guideline

### DIFF
--- a/.github/BRANCHING.md
+++ b/.github/BRANCHING.md
@@ -1,0 +1,92 @@
+[200~# Branching Strategy
+
+> This repository follows a Dev → Main workflow model optimized for continuous development and safe releases.
+> 
+
+---
+
+### Branch Overview
+
+| Branch | Purpose | Rules |
+| --- | --- | --- |
+| `main` | **Production-ready code** only. Used for deployment and releases. | Protected branch. No direct commits. |
+| `dev` | **Integration branch.** All features and fixes merge here before release. | Default branch. All PRs merge into `dev`. |
+| `feature/*` | Individual features or experiments (e.g. `feature/observability`) | Created from `dev`. Merge back via PR. |
+| `hotfix/*` | Urgent production fixes. | Created from `main`, merged into both `main` and `dev`. |
+
+---
+
+### Workflow Summary
+
+1. **Start from `dev`**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/<feature-name>
+```
+
+1. **Work and Commit**
+
+```bash
+# example
+git add .
+git commit -m "feat(observability): add ray serve inference endpoint"
+```
+
+1. **Push and Open PR**
+
+```bash
+git push origin feature/<feature-name>
+```
+
+Then open a **Pull Request → `dev`**.
+
+1.  **Integration and Testing**
+- All new code is merged into `dev`.
+- Run tests, linting, and validation pipelines here.
+
+1. **Release to Main**
+
+```bash
+# Merge dev → main after QA validation
+git checkout main
+git merge dev --no-ff -m "release: merge dev into main for v1.0.0"
+git push origin main
+```
+
+---
+
+### Branch Flow
+
+```
+main
+ └── dev
+       ├── feature/mlflow-tracking
+             ├── feature/ray-serve-api
+                   └── hotfix/logging-timeout
+                   ```
+
+                   ---
+
+### Protection Rules
+
+| Branch | Rule | Description |
+| --- | --- | --- |
+| `main` | Require PRs + Approvals | Prevents direct push or deletion |
+| `dev` | Require PRs | Controls feature merges and avoids broken builds |
+
+---
+
+### Notes
+
+- Use **squash & merge** to keep history clean.
+- Prefix commits with a type:
+    - `feat:` → New feature
+        - `fix:` → Bug fix
+            - `docs:` → Documentation
+                - `refactor:` → Code cleanup
+                    - `chore:` → CI/CD or config updates
+                        
+
+                        ---

--- a/.github/commit_template.txt
+++ b/.github/commit_template.txt
@@ -1,0 +1,19 @@
+# [타입]: [변경 요약]
+# 예: feat: add Airflow DAG for MLflow tracking
+#
+# 타입 (하나 선택):
+#   feat     : 새로운 기능 추가
+#   fix      : 버그 수정
+#   docs     : 문서 수정
+#   style    : 포맷팅, 세미콜론 누락 등 코드 변경 없음
+#   refactor : 코드 리팩토링 (기능 변경 없음)
+#   test     : 테스트 추가 또는 수정
+#   chore    : 빌드, 설정 파일, 기타 유지보수
+#
+# 본문 (선택):
+# - 왜 이 변경을 했는지 설명
+# - 관련된 이슈 번호를 언급 (#123)
+#
+# 꼬리말 (선택):
+# BREAKING CHANGE: 호환성 깨지는 변경사항
+# Closes #123, Resolves #456


### PR DESCRIPTION
## Summary
- Add **branching strategy guideline** at `.github/BRANCHING.md`
- Document the **Dev → Main** workflow:
  - `main`: release/production only (protected)
  - `dev`: default integration branch
  - `feature/*`: short-lived feature branches merged into `dev`
  - `hotfix/*`: urgent fixes branched from `main`, merged back to both `main` and `dev`

## Changes
- New file: `.github/BRANCHING.md`
- Content includes:
  - Branch purposes and rules
  - Daily workflow commands (feature → dev → main)
  - Hotfix flow
  - Recommended protection settings (PRs, approvals, linear history)

## Rationale
- Establish a clear, enforceable workflow for consistent collaboration and safe releases.
- Align repository protection rules with our process (PR-first on `dev`, release-only `main`).

## How to Test
- Review `.github/BRANCHING.md` renders properly on GitHub (tables, code blocks).
- Validate the steps by creating a sample `feature/<name>` branch and opening a PR into `dev`.

## Checklist
- [x] Documentation added
- [x] Matches current branch protection rules
- [x] No code or runtime changes
- [ ] (Optional) Add PR template in `.github/pull_request_template.md`
- [ ] (Optional) Add CODEOWNERS for default reviewers

## Impact
- **Dev workflow clarity** for all contributors
- Enables consistent PR reviews and clean release process

## Related
- N/A (initial documentation)
