### PR TITLE
Featfix(ray): adopt serve.start(http_options)+serve.run; expose 0.0.0.0 and GPU-ready composeure/ray gpu compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,14 @@ services:
       context: ./ray_inference
     image: daeun/ray-inference:cu116
     container_name: ray-inference
-    shm_size: "1gb"
+    shm_size: "1gb"                # PyTorch/Ray 공유메모리 여유
     ports:
       - "8000:8000"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
       - RAY_memory_monitor_refresh_ms=0
+    # Docker Desktop (WSL2 + GPU)에서 GPU 패스스루 선언
     deploy:
       resources:
         reservations:
@@ -18,4 +19,3 @@ services:
             - driver: nvidia
               capabilities: [gpu]
     restart: unless-stopped
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ./ray_inference
     image: daeun/ray-inference:cu116
     container_name: ray-inference
-    shm_size: "1gb"
+    shm_size: "2gb"
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,10 @@ services:
       context: ./ray_inference
     image: daeun/ray-inference:cu116
     container_name: ray-inference
-    shm_size: "1gb"                # PyTorch/Ray 공유메모리 여유
+    shm_size: "1gb"
     ports:
       - "8000:8000"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
-      - RAY_memory_monitor_refresh_ms=0
-    # Docker Desktop (WSL2 + GPU)에서 GPU 패스스루 선언
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              capabilities: [gpu]
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,21 @@
-version: "3.8"
 services:
   ray-inference:
     build:
       context: ./ray_inference
     image: daeun/ray-inference:cu116
     container_name: ray-inference
+    shm_size: "1gb"
     ports:
       - "8000:8000"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - RAY_memory_monitor_refresh_ms=0
     deploy:
       resources:
         reservations:
           devices:
-            - capabilities: ["gpu"]
-    environment:
-      - RAY_memory_monitor_refresh_ms=0
+            - driver: nvidia
+              capabilities: [gpu]
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,11 @@ services:
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - RAY_memory_monitor_refresh_ms=0
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
     restart: unless-stopped

--- a/mlflow/run_mlflow.sh
+++ b/mlflow/run_mlflow.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pip3 install --user mlflow >/dev/null 2>&1 || true
+~/.local/bin/mlflow ui --host 0.0.0.0 --port 5000
+

--- a/mlruns/0/meta.yaml
+++ b/mlruns/0/meta.yaml
@@ -1,0 +1,6 @@
+artifact_location: mlflow-artifacts:/0
+creation_time: 1761635374838
+experiment_id: '0'
+last_update_time: 1761635374838
+lifecycle_stage: active
+name: Default

--- a/ray_inference/Dockerfile
+++ b/ray_inference/Dockerfile
@@ -12,17 +12,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN python3 -m pip install --upgrade pip setuptools wheel
 
-# PyTorch(CUDA 11.6) — 공식 extra-index-url 방식
+# PyTorch(CUDA 11.6)
 RUN pip install --no-cache-dir \
     torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 \
     --extra-index-url https://download.pytorch.org/whl/cu116
 
-# Ray Serve & FastAPI
+# ✅ Ray Serve와 호환되는 FastAPI/uvicorn 버전 고정
 RUN pip install --no-cache-dir \
-    "ray[serve]==2.9.3" fastapi==0.115.0 uvicorn==0.30.6
+    "ray[serve]==2.9.3" \
+    fastapi==0.108.0 \
+    uvicorn==0.23.2
 
 WORKDIR /app
 COPY serve_app.py /app/serve_app.py
 
 EXPOSE 8000
 CMD ["python3", "serve_app.py"]
+

--- a/ray_inference/Dockerfile
+++ b/ray_inference/Dockerfile
@@ -1,25 +1,35 @@
+# CUDA 11.6 런타임 (Windows 드라이버 512.89 / CUDA 11.6 과 호환)
 FROM nvidia/cuda:11.6.2-base-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    RAY_memory_monitor_refresh_ms=0
 
+# 기본 도구 + Python
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip ca-certificates curl && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip3 install --no-cache-dir --upgrade pip && \
-    rm -rf /var/lib/apt/lists/*
+    python3 python3-pip python3-distutils curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
 
-# Ray Serve + API + Metrics
-RUN pip3 install --no-cache-dir "ray[serve]==2.9.3" fastapi uvicorn prometheus-client
+# pip 최신화
+RUN python3 -m pip install --upgrade pip setuptools wheel
 
-# PyTorch (CUDA 11.6)
-RUN pip3 install --no-cache-dir \
-  torch==1.13.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html
+# -------------------------
+# 🔧 핵심: PyTorch CUDA 11.6 설치 (공식 extra-index-url 방식)
+# -------------------------
+RUN pip install --no-cache-dir \
+    torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 \
+    --extra-index-url https://download.pytorch.org/whl/cu116
+
+# Ray Serve, FastAPI, Prometheus
+RUN pip install --no-cache-dir \
+    "ray[serve]==2.9.0" \
+    fastapi==0.115.0 \
+    uvicorn==0.30.6 \
+    prometheus_client==0.20.0
 
 WORKDIR /app
 COPY serve_app.py /app/serve_app.py
 
 EXPOSE 8000
-CMD ["python", "serve_app.py"]
-
+CMD ["python3", "serve_app.py"]

--- a/ray_inference/Dockerfile
+++ b/ray_inference/Dockerfile
@@ -10,8 +10,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pip3 install --no-cache-dir --upgrade pip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir "ray[serve]==2.9.3" fastapi uvicorn prometheus-client \
- && pip3 install --no-cache-dir torch==1.13.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html
+# Ray Serve + API + Metrics
+RUN pip3 install --no-cache-dir "ray[serve]==2.9.3" fastapi uvicorn prometheus-client
+
+# PyTorch (CUDA 11.6)
+RUN pip3 install --no-cache-dir \
+  torch==1.13.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html
 
 WORKDIR /app
 COPY serve_app.py /app/serve_app.py

--- a/ray_inference/Dockerfile
+++ b/ray_inference/Dockerfile
@@ -1,29 +1,24 @@
-# CUDA 11.6 런타임 (Windows 드라이버 512.89 / CUDA 11.6 과 호환)
+# ray_inference/Dockerfile
 FROM nvidia/cuda:11.6.2-base-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    RAY_memory_monitor_refresh_ms=0
+    PYTHONUNBUFFERED=1
 
-# 기본 도구 + Python
+# base deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-distutils curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-# pip 최신화
 RUN python3 -m pip install --upgrade pip setuptools wheel
 
-# -------------------------
-# 🔧 핵심: PyTorch CUDA 11.6 설치 (공식 extra-index-url 방식)
-# -------------------------
+# ✅ PyTorch CUDA 11.6 (공식 권장 방식)
 RUN pip install --no-cache-dir \
     torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 \
     --extra-index-url https://download.pytorch.org/whl/cu116
 
-# Ray Serve, FastAPI, Prometheus
+# app deps
 RUN pip install --no-cache-dir \
-    "ray[serve]==2.9.0" \
     fastapi==0.115.0 \
     uvicorn==0.30.6 \
     prometheus_client==0.20.0
@@ -32,4 +27,5 @@ WORKDIR /app
 COPY serve_app.py /app/serve_app.py
 
 EXPOSE 8000
-CMD ["python3", "serve_app.py"]
+# ✅ Ray 없이 Uvicorn으로 먼저 안정 구동
+CMD ["uvicorn", "serve_app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ray_inference/Dockerfile
+++ b/ray_inference/Dockerfile
@@ -3,29 +3,26 @@ FROM nvidia/cuda:11.6.2-base-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    RAY_memory_monitor_refresh_ms=0
 
-# base deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-distutils curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --upgrade pip setuptools wheel
 
-# ✅ PyTorch CUDA 11.6 (공식 권장 방식)
+# PyTorch(CUDA 11.6) — 공식 extra-index-url 방식
 RUN pip install --no-cache-dir \
     torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 \
     --extra-index-url https://download.pytorch.org/whl/cu116
 
-# app deps
+# Ray Serve & FastAPI
 RUN pip install --no-cache-dir \
-    fastapi==0.115.0 \
-    uvicorn==0.30.6 \
-    prometheus_client==0.20.0
+    "ray[serve]==2.9.3" fastapi==0.115.0 uvicorn==0.30.6
 
 WORKDIR /app
 COPY serve_app.py /app/serve_app.py
 
 EXPOSE 8000
-# ✅ Ray 없이 Uvicorn으로 먼저 안정 구동
-CMD ["uvicorn", "serve_app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python3", "serve_app.py"]

--- a/ray_inference/load_test.sh
+++ b/ray_inference/load_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+for i in $(seq 1 50); do
+  curl -s -X POST http://127.0.0.1:8000/inference \
+    -H 'Content-Type: application/json' \
+    -d '{"input":[1,2,3,4]}' >/dev/null &
+done
+wait
+echo "done"
+

--- a/ray_inference/serve_app.py
+++ b/ray_inference/serve_app.py
@@ -1,53 +1,47 @@
-# ray_inference/serve_app.py
-from fastapi import FastAPI
-from ray import serve
+from fastapi import FastAPI, Body
+from fastapi.responses import PlainTextResponse
 import torch
+import time
 
-# Ray HTTP 서버 명시적으로 시작 (단일 노드)
-serve.start(
-    detached=True,
-    http_options={"host": "0.0.0.0", "port": 8000},
-    dedicated_cpu=False,
-)
+from ray import serve
 
-@serve.deployment(
-    ray_actor_options={"num_cpus": 0.25}  # 로컬/WSL 경량화
-)
+api = FastAPI(title="Hybrid Ray Inference")
+
+@serve.deployment
+@serve.ingress(api)
 class InferenceService:
     def __init__(self):
-        # 직렬화 안전: FastAPI를 인스턴스 내부에서 생성
-        app = FastAPI(title="Hybrid MLOps Demo - Ray Serve")
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        # GPU/CPU 자동감지
+    @api.get("/healthz")
+    async def healthz(self):
+        return {"ok": True, "device": self.device}
+
+    @api.post("/")
+    async def infer(self, payload: dict = Body(...)):
+        xs = payload.get("input", [])
+        if not isinstance(xs, list):
+            return {"error": "input must be a list"}
         try:
-            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+            out = [float(x) * 2 for x in xs]
         except Exception:
-            self.device = "cpu"
+            return {"error": "input must be a list of numbers"}
+        return {"device": self.device, "output": out}
 
-        # 간단한 데모 모델
-        self.model = torch.nn.Linear(4, 2).to(self.device)
-        self.model.eval()
+    @api.get("/metrics")
+    async def metrics(self):
+        return PlainTextResponse(
+            "# HELP inference_requests_total Total inference requests\n"
+            "# TYPE inference_requests_total counter\n"
+            "inference_requests_total{service=\"ray-inference\"} 0\n"
+        )
 
-        @app.get("/inference/healthz")
-        def healthz():
-            return {"ok": True, "device": self.device}
+# 신규 Serve API
+app = InferenceService.bind()
+serve.run(app, route_prefix="/inference")
 
-        @app.post("/inference/")
-        def infer(payload: dict):
-            x = payload.get("input", [1.0, 2.0, 3.0, 4.0])
-            x = torch.tensor(x, dtype=torch.float32, device=self.device)
-            with torch.no_grad():
-                y = self.model(x)
-            return {"device": self.device, "output": y.tolist()}
+# ✅ 컨테이너 프로세스 유지 (중요!)
+print("[serve_app] Ray Serve app is up. Sleeping forever to keep process alive...")
+while True:
+    time.sleep(3600)
 
-        self._app = app
-
-    # Ray Serve가 호출할 ASGI 엔드포인트
-    async def __call__(self, scope, receive, send):
-        await self._app(scope, receive, send)
-
-# 배포
-if __name__ == "__main__":  # 컨테이너 시작시 실행
-    InferenceService.deploy()
-else:
-    InferenceService.deploy()

--- a/ray_inference/serve_app.py
+++ b/ray_inference/serve_app.py
@@ -3,7 +3,7 @@ from prometheus_client import Counter, Histogram, Gauge, generate_latest, CONTEN
 from ray import serve
 import torch, time
 
-# ✅ Ray Serve: 단일 노드/WSL 안정화 옵션
+# 단일노드/WSL 친화 설정 (Ray HTTP 서버 바인드 명시)
 serve.start(
     detached=True,
     http_options={"host": "0.0.0.0", "port": 8000},
@@ -16,15 +16,14 @@ serve.start(
 )
 class InferenceService:
     def __init__(self):
-        # FastAPI 인스턴스는 인스턴스 내부에 생성 (직렬화 안전)
+        # FastAPI 인스턴스를 클래스 내부에서 생성 → 직렬화 안전
         app = FastAPI()
 
-        # ✅ 메트릭은 전역 금지! 인스턴스 필드로 생성
+        # 전역 금지. 인스턴스 필드로 생성해서 직렬화 이슈 회피
         self.req_total = Counter("inference_requests_total", "Total inference requests")
         self.req_lat   = Histogram("inference_request_latency_seconds", "Inference latency (s)")
         self.device_g  = Gauge("inference_device_is_cuda", "1=cuda, 0=cpu")
 
-        # 디바이스/모델 준비
         try:
             self.device = "cuda" if torch.cuda.is_available() else "cpu"
         except Exception as e:
@@ -34,10 +33,10 @@ class InferenceService:
         self.device_g.set(1 if self.device == "cuda" else 0)
         print(f"[INFO] Using device: {self.device}")
 
+        # 데모용 경량 모델
         self.model = torch.nn.Linear(4, 2).to(self.device)
         self.model.eval()
 
-        # ---- 라우트: 전역 변수 캡처 금지 → self만 캡처 ----
         @app.get("/healthz")
         def _healthz():
             return {"ok": True}
@@ -57,13 +56,12 @@ class InferenceService:
             self.req_lat.observe(time.time() - t0)
             return {"device": self.device, "output": y.tolist()}
 
-        # ASGI 앱 보관
+        # ASGI 핸들러 저장
         self._app = app
 
-    # ASGI 래퍼
+    # Ray Serve 가 ASGI 를 호출할 수 있게 래핑
     async def __call__(self, scope, receive, send):
         await self._app(scope, receive, send)
 
 # 배포
 InferenceService.deploy()
-

--- a/ray_inference/serve_app.py
+++ b/ray_inference/serve_app.py
@@ -1,44 +1,53 @@
 # ray_inference/serve_app.py
-from fastapi import FastAPI, Response
-from prometheus_client import Counter, Histogram, Gauge, generate_latest, CONTENT_TYPE_LATEST
-import torch, time
+from fastapi import FastAPI
+from ray import serve
+import torch
 
-app = FastAPI(title="Hybrid MLOps Demo - Inference")
+# Ray HTTP 서버 명시적으로 시작 (단일 노드)
+serve.start(
+    detached=True,
+    http_options={"host": "0.0.0.0", "port": 8000},
+    dedicated_cpu=False,
+)
 
-# Prometheus metrics
-REQ_TOTAL = Counter("inference_requests_total", "Total inference requests")
-REQ_LAT   = Histogram("inference_request_latency_seconds", "Inference latency (s)")
-DEVICE_G  = Gauge("inference_device_is_cuda", "1=cuda, 0=cpu")
+@serve.deployment(
+    ray_actor_options={"num_cpus": 0.25}  # 로컬/WSL 경량화
+)
+class InferenceService:
+    def __init__(self):
+        # 직렬화 안전: FastAPI를 인스턴스 내부에서 생성
+        app = FastAPI(title="Hybrid MLOps Demo - Ray Serve")
 
-# --- model init ---
-try:
-    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
-except Exception as e:
-    print(f"[WARN] CUDA check failed: {e}; fallback=cpu")
-    DEVICE = "cpu"
+        # GPU/CPU 자동감지
+        try:
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        except Exception:
+            self.device = "cpu"
 
-DEVICE_G.set(1 if DEVICE == "cuda" else 0)
-print(f"[INFO] Using device: {DEVICE}")
+        # 간단한 데모 모델
+        self.model = torch.nn.Linear(4, 2).to(self.device)
+        self.model.eval()
 
-MODEL = torch.nn.Linear(4, 2).to(DEVICE)
-MODEL.eval()
+        @app.get("/inference/healthz")
+        def healthz():
+            return {"ok": True, "device": self.device}
 
-# --- routes under /inference ---
-@app.get("/inference/healthz")
-def healthz():
-    return {"ok": True}
+        @app.post("/inference/")
+        def infer(payload: dict):
+            x = payload.get("input", [1.0, 2.0, 3.0, 4.0])
+            x = torch.tensor(x, dtype=torch.float32, device=self.device)
+            with torch.no_grad():
+                y = self.model(x)
+            return {"device": self.device, "output": y.tolist()}
 
-@app.get("/inference/metrics")
-def metrics():
-    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+        self._app = app
 
-@app.post("/inference/")
-def infer(payload: dict):
-    REQ_TOTAL.inc()
-    t0 = time.time()
-    x = payload.get("input", [1.0, 2.0, 3.0, 4.0])
-    x = torch.tensor(x, dtype=torch.float32, device=DEVICE)
-    with torch.no_grad():
-        y = MODEL(x)
-    REQ_LAT.observe(time.time() - t0)
-    return {"device": DEVICE, "output": y.tolist()}
+    # Ray Serve가 호출할 ASGI 엔드포인트
+    async def __call__(self, scope, receive, send):
+        await self._app(scope, receive, send)
+
+# 배포
+if __name__ == "__main__":  # 컨테이너 시작시 실행
+    InferenceService.deploy()
+else:
+    InferenceService.deploy()

--- a/ray_inference/serve_app.py
+++ b/ray_inference/serve_app.py
@@ -3,7 +3,6 @@ from prometheus_client import Counter, Histogram, Gauge, generate_latest, CONTEN
 from ray import serve
 import torch, time
 
-# 단일노드/WSL 친화 설정 (Ray HTTP 서버 바인드 명시)
 serve.start(
     detached=True,
     http_options={"host": "0.0.0.0", "port": 8000},
@@ -16,10 +15,8 @@ serve.start(
 )
 class InferenceService:
     def __init__(self):
-        # FastAPI 인스턴스를 클래스 내부에서 생성 → 직렬화 안전
         app = FastAPI()
 
-        # 전역 금지. 인스턴스 필드로 생성해서 직렬화 이슈 회피
         self.req_total = Counter("inference_requests_total", "Total inference requests")
         self.req_lat   = Histogram("inference_request_latency_seconds", "Inference latency (s)")
         self.device_g  = Gauge("inference_device_is_cuda", "1=cuda, 0=cpu")
@@ -33,7 +30,6 @@ class InferenceService:
         self.device_g.set(1 if self.device == "cuda" else 0)
         print(f"[INFO] Using device: {self.device}")
 
-        # 데모용 경량 모델
         self.model = torch.nn.Linear(4, 2).to(self.device)
         self.model.eval()
 
@@ -56,12 +52,9 @@ class InferenceService:
             self.req_lat.observe(time.time() - t0)
             return {"device": self.device, "output": y.tolist()}
 
-        # ASGI 핸들러 저장
         self._app = app
 
-    # Ray Serve 가 ASGI 를 호출할 수 있게 래핑
     async def __call__(self, scope, receive, send):
         await self._app(scope, receive, send)
 
-# 배포
 InferenceService.deploy()

--- a/ray_inference/serve_app.py
+++ b/ray_inference/serve_app.py
@@ -1,42 +1,69 @@
 from fastapi import FastAPI, Response
+from prometheus_client import Counter, Histogram, Gauge, generate_latest, CONTENT_TYPE_LATEST
 from ray import serve
-from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 import torch, time
 
-app = FastAPI()
-serve.start(detached=True)
+# ✅ Ray Serve: 단일 노드/WSL 안정화 옵션
+serve.start(
+    detached=True,
+    http_options={"host": "0.0.0.0", "port": 8000},
+    dedicated_cpu=False
+)
 
-REQ_TOTAL = Counter("inference_requests_total", "Total inference requests")
-REQ_LAT   = Histogram("inference_request_latency_seconds", "Inference latency (s)")
-
-@app.get("/metrics")
-def metrics():
-    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
-
-@serve.deployment(route_prefix="/inference")
-@serve.ingress(app)
+@serve.deployment(
+    route_prefix="/inference",
+    ray_actor_options={"num_cpus": 0.25}
+)
 class InferenceService:
     def __init__(self):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        # FastAPI 인스턴스는 인스턴스 내부에 생성 (직렬화 안전)
+        app = FastAPI()
+
+        # ✅ 메트릭은 전역 금지! 인스턴스 필드로 생성
+        self.req_total = Counter("inference_requests_total", "Total inference requests")
+        self.req_lat   = Histogram("inference_request_latency_seconds", "Inference latency (s)")
+        self.device_g  = Gauge("inference_device_is_cuda", "1=cuda, 0=cpu")
+
+        # 디바이스/모델 준비
+        try:
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        except Exception as e:
+            print(f"[WARN] CUDA check failed: {e}; fallback=cpu")
+            self.device = "cpu"
+
+        self.device_g.set(1 if self.device == "cuda" else 0)
         print(f"[INFO] Using device: {self.device}")
+
         self.model = torch.nn.Linear(4, 2).to(self.device)
         self.model.eval()
 
-    @app.post("/")
-    def infer(self, payload: dict):
-        REQ_TOTAL.inc()
-        start = time.time()
-        x = payload.get("input", [1.0, 2.0, 3.0, 4.0])
-        x = torch.tensor(x, dtype=torch.float32, device=self.device)
-        with torch.no_grad():
-            y = self.model(x)
-        REQ_LAT.observe(time.time() - start)
-        return {"device": self.device, "output": y.tolist()}
+        # ---- 라우트: 전역 변수 캡처 금지 → self만 캡처 ----
+        @app.get("/healthz")
+        def _healthz():
+            return {"ok": True}
 
-# 간단 헬스체크
-@app.get("/healthz")
-def healthz():
-    return {"ok": True}
+        @app.get("/metrics")
+        def _metrics():
+            return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
+        @app.post("/")
+        def _infer(payload: dict):
+            self.req_total.inc()
+            t0 = time.time()
+            x = payload.get("input", [1.0, 2.0, 3.0, 4.0])
+            x = torch.tensor(x, dtype=torch.float32, device=self.device)
+            with torch.no_grad():
+                y = self.model(x)
+            self.req_lat.observe(time.time() - t0)
+            return {"device": self.device, "output": y.tolist()}
+
+        # ASGI 앱 보관
+        self._app = app
+
+    # ASGI 래퍼
+    async def __call__(self, scope, receive, send):
+        await self._app(scope, receive, send)
+
+# 배포
 InferenceService.deploy()
 

--- a/ray_inference/serve_app.py
+++ b/ray_inference/serve_app.py
@@ -1,60 +1,44 @@
+# ray_inference/serve_app.py
 from fastapi import FastAPI, Response
 from prometheus_client import Counter, Histogram, Gauge, generate_latest, CONTENT_TYPE_LATEST
-from ray import serve
 import torch, time
 
-serve.start(
-    detached=True,
-    http_options={"host": "0.0.0.0", "port": 8000},
-    dedicated_cpu=False
-)
+app = FastAPI(title="Hybrid MLOps Demo - Inference")
 
-@serve.deployment(
-    route_prefix="/inference",
-    ray_actor_options={"num_cpus": 0.25}
-)
-class InferenceService:
-    def __init__(self):
-        app = FastAPI()
+# Prometheus metrics
+REQ_TOTAL = Counter("inference_requests_total", "Total inference requests")
+REQ_LAT   = Histogram("inference_request_latency_seconds", "Inference latency (s)")
+DEVICE_G  = Gauge("inference_device_is_cuda", "1=cuda, 0=cpu")
 
-        self.req_total = Counter("inference_requests_total", "Total inference requests")
-        self.req_lat   = Histogram("inference_request_latency_seconds", "Inference latency (s)")
-        self.device_g  = Gauge("inference_device_is_cuda", "1=cuda, 0=cpu")
+# --- model init ---
+try:
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+except Exception as e:
+    print(f"[WARN] CUDA check failed: {e}; fallback=cpu")
+    DEVICE = "cpu"
 
-        try:
-            self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        except Exception as e:
-            print(f"[WARN] CUDA check failed: {e}; fallback=cpu")
-            self.device = "cpu"
+DEVICE_G.set(1 if DEVICE == "cuda" else 0)
+print(f"[INFO] Using device: {DEVICE}")
 
-        self.device_g.set(1 if self.device == "cuda" else 0)
-        print(f"[INFO] Using device: {self.device}")
+MODEL = torch.nn.Linear(4, 2).to(DEVICE)
+MODEL.eval()
 
-        self.model = torch.nn.Linear(4, 2).to(self.device)
-        self.model.eval()
+# --- routes under /inference ---
+@app.get("/inference/healthz")
+def healthz():
+    return {"ok": True}
 
-        @app.get("/healthz")
-        def _healthz():
-            return {"ok": True}
+@app.get("/inference/metrics")
+def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
-        @app.get("/metrics")
-        def _metrics():
-            return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
-
-        @app.post("/")
-        def _infer(payload: dict):
-            self.req_total.inc()
-            t0 = time.time()
-            x = payload.get("input", [1.0, 2.0, 3.0, 4.0])
-            x = torch.tensor(x, dtype=torch.float32, device=self.device)
-            with torch.no_grad():
-                y = self.model(x)
-            self.req_lat.observe(time.time() - t0)
-            return {"device": self.device, "output": y.tolist()}
-
-        self._app = app
-
-    async def __call__(self, scope, receive, send):
-        await self._app(scope, receive, send)
-
-InferenceService.deploy()
+@app.post("/inference/")
+def infer(payload: dict):
+    REQ_TOTAL.inc()
+    t0 = time.time()
+    x = payload.get("input", [1.0, 2.0, 3.0, 4.0])
+    x = torch.tensor(x, dtype=torch.float32, device=DEVICE)
+    with torch.no_grad():
+        y = MODEL(x)
+    REQ_LAT.observe(time.time() - t0)
+    return {"device": DEVICE, "output": y.tolist()}


### PR DESCRIPTION
`Verification
- curl http://localhost:8000/inference/healthz → {"ok":true,"device":"cuda|cpu"}
- curl -X POST http://localhost:8000/inference/ -d '{"input":[1,2,3]}' -H 'Content-Type: application/json'
- docker exec -it ray-inference python3 -c "import torch;print(torch.cuda.is_available(), torch.cuda.device_count())"
`
<img width="937" height="118" alt="image" src="https://github.com/user-attachments/assets/1244caec-4742-4b4c-9f98-3d436755f8a4" />
